### PR TITLE
use fill and set brightness only once

### DIFF
--- a/3dPrinterMonitor.ino
+++ b/3dPrinterMonitor.ino
@@ -43,6 +43,7 @@ void setup()
 
   strip.begin();
   strip.show();
+  strip.setBrightness(brightness);
 }
 
 //Push data
@@ -102,16 +103,11 @@ void loop()
       
       
   // Change color
-  for(int i=0; i<12; i++)
-  {
-    strip.setBrightness(brightness);
-
-    if(state == 2)
-      strip.setPixelColor(i, strip.Color(255, 0, 0));
-    else if(state == 1)
-      strip.setPixelColor(i, strip.Color(255, 255, 0));
-    else
-      strip.setPixelColor(i, strip.Color(0, 255, 0));
-  }
+  if(state == 2)
+    strip.fill(strip.Color(255, 0, 0));
+  else if(state == 1)
+    strip.fill(strip.Color(255, 255, 0));
+  else
+    strip.fill(strip.Color(0, 255, 0));
   strip.show();
 }


### PR DESCRIPTION
[`Adafruit_NeoPixel::fill`](https://adafruit.github.io/Adafruit_NeoPixel/html/class_adafruit___neo_pixel.html#a310844b3e5580056edf52ce3268d8084) is and easier convenience function so I replaced the for loop to make the code cleaner. 

> **[setBrightness()](https://adafruit.github.io/Adafruit_NeoPixel/html/class_adafruit___neo_pixel.html#aa05f7d37828c43fef00e6242dcf75959)** was intended to be called once, in setup(), to limit the current/brightness of the LEDs throughout the life of the sketch. It is not intended as an animation effect itself! The operation of this function is “lossy” — it modifies the current pixel data in RAM, not in the show() call — in order to meet NeoPixels’ strict timing requirements.

source: https://learn.adafruit.com/adafruit-neopixel-uberguide/arduino-library-use

Per that quote from the docs, I moved the `setBrightness()` call to `setup()` (after `strip.show()` as it is in the example strandtest)